### PR TITLE
Request with HEAD method cannot have body

### DIFF
--- a/src/oauth-backend.js
+++ b/src/oauth-backend.js
@@ -52,7 +52,7 @@ export default class OAuthBackend extends AuthBackend {
 		}
 
 		if (type(req.body) === "object") {
-			if (req.method == "GET") {
+			if (req.method === "GET" || req.method === "HEAD") {
 				for (let p in req.body) {
 					let action = req.body[p] === undefined? "delete" : "set";
 					call.searchParams[action](p, req.body[p]);


### PR DESCRIPTION
Otherwise, we get the “Failed to execute 'fetch' on 'Window'” error.