### PR TITLE
Better separation of auth concerns

### DIFF
--- a/backends/google/firebase/google-firebase.js
+++ b/backends/google/firebase/google-firebase.js
@@ -205,30 +205,28 @@ export default class GoogleFirebase extends Google {
 	}
 
 	async login ({ passive } = {}) {
-		await this.ready;
+		let user = await super.login(...args);
 
-		if (!passive) {
-			try {
-				const auth = getAuth(this.app);
-				const provider = new GoogleAuthProvider();
-
-				// Apply the default browser preference.
-				useDeviceLanguage(auth);
-
-				await signInWithPopup(auth, provider);
-			}
-			catch (e) {
-				throw new Error(e.message);
-			}
-		}
-
-		const user = await this.getUser();
 		if (user) {
-			this.dispatchEvent(new CustomEvent("mv-login"));
-			this.updatePermissions({ login: false, logout: true, edit: true, save: true });
+			this.updatePermissions({edit: true, save: true});
 		}
 
 		return user;
+	}
+
+	async activeLogin () {
+		try {
+			const auth = getAuth(this.app);
+			const provider = new GoogleAuthProvider();
+
+			// Apply the default browser preference.
+			useDeviceLanguage(auth);
+
+			await signInWithPopup(auth, provider);
+		}
+		catch (e) {
+			throw new Error(e.message);
+		}
 	}
 
 	async logout () {
@@ -240,10 +238,6 @@ export default class GoogleFirebase extends Google {
 		catch (e) {
 			throw new Error(e.message);
 		}
-	}
-
-	async getUser () {
-		return this.user;
 	}
 
 	#applyDefaults (file = this.file) {

--- a/backends/google/firebase/google-firebase.js
+++ b/backends/google/firebase/google-firebase.js
@@ -205,7 +205,7 @@ export default class GoogleFirebase extends Google {
 	}
 
 	async login ({ passive } = {}) {
-		let user = await super.login(...args);
+		let user = await super.login(...arguments);
 
 		if (user) {
 			this.updatePermissions({edit: true, save: true});

--- a/backends/google/firebase/google-firebase.js
+++ b/backends/google/firebase/google-firebase.js
@@ -34,7 +34,7 @@ export default class GoogleFirebase extends Google {
 
 			if (this.app) {
 				const auth = getAuth(this.app);
-				onAuthStateChanged(auth, async (user) => {
+				onAuthStateChanged(auth, (user) => {
 					if (user) {
 						// User is signed in
 						this.user = {

--- a/backends/google/firebase/google-firebase.js
+++ b/backends/google/firebase/google-firebase.js
@@ -204,10 +204,11 @@ export default class GoogleFirebase extends Google {
 		}
 	}
 
-	async login ({ passive } = {}) {
-		let user = await super.login(...arguments);
+	async login (options) {
+		let user = await super.login(options);
 
 		if (user) {
+			// TODO figure out actual permissions
 			this.updatePermissions({edit: true, save: true});
 		}
 

--- a/src/auth-backend.js
+++ b/src/auth-backend.js
@@ -16,7 +16,7 @@ export default class AuthBackend extends Backend {
 
 	/**
 	 * Is current user authenticated?
-	 * Sycnrhonous because it must not trigger any API calls, use passiveLogin() for that
+	 * Synchronous because it must not trigger any API calls, use passiveLogin() for that
 	 * @returns {boolean}
 	 */
 	isAuthenticated () {
@@ -43,11 +43,11 @@ export default class AuthBackend extends Backend {
 			return this.getUser();
 		}
 
-		await passiveLogin(rest);
+		await this.passiveLogin(rest);
 
 		if (this.isAuthenticated()) {
 			try {
-				await this.getUser()
+				await this.getUser();
 			}
 			catch (e) {
 				if (e.status == 401) {
@@ -116,5 +116,5 @@ export default class AuthBackend extends Backend {
 
 	static phrases = {
 		"authentication_error": "Authentication error",
-	}
+	};
 }

--- a/src/auth-backend.js
+++ b/src/auth-backend.js
@@ -88,7 +88,7 @@ export default class AuthBackend extends Backend {
 	async logout () {
 		let wasAuthenticated = this.isAuthenticated();
 
-		if (wasAuthenticated || force) {
+		if (wasAuthenticated) {
 			this.deleteLocalUserInfo();
 
 			// TODO does this really represent all backends? Should it be a setting?

--- a/src/auth-backend.js
+++ b/src/auth-backend.js
@@ -13,6 +13,11 @@ export default class AuthBackend extends Backend {
 		this.login({passive: true});
 	}
 
+	/**
+	 * Is current user authenticated?
+	 * Sycnrhonous because it must not trigger any API calls, use passiveLogin() for that
+	 * @returns {boolean}
+	 */
 	isAuthenticated () {
 		return !!this.user;
 	}
@@ -23,7 +28,62 @@ export default class AuthBackend extends Backend {
 		}
 	}
 
-	async login () {}
+	/**
+	 * Log a user in, either passively (without triggering any login UI) or actively (with login UI)
+	 * @param [options] {object}
+	 * @param [options.passive] {boolean} - Do not trigger any login UI, just return the current user if already logged in
+	 */
+	async login ({passive = false, ...rest} = {}) {
+		if (this.ready) {
+			await this.ready;
+		}
+
+		if (this.isAuthenticated()) {
+			return this.getUser();
+		}
+
+		await passiveLogin(rest);
+
+		if (this.isAuthenticated()) {
+			try {
+				await this.getUser()
+			}
+			catch (e) {
+				if (e.status == 401) {
+					// Unauthorized. We have corrupt local data, discard it
+					this.logout({force: true})
+				}
+			}
+		}
+
+		if (!passive && !this.isAuthenticated()) {
+			await this.activeLogin(rest);
+		}
+
+		if (this.isAuthenticated()) {
+			let user = await this.getUser();
+			this.dispatchEvent(new CustomEvent("mv-login"));
+			this.updatePermissions({login: false, logout: true});
+			return user;
+		}
+	}
+
+	/**
+	 * @abstract
+	 * Show authentication UI to the user. Must be implemented by subclasses
+	 */
+	async activeLogin () {
+		throw new TypeError("Not implemented");
+	}
+
+	/**
+	 * @abstract
+	 * Try to authenticate a previously authenticated user (i.e. without showing any login UI)
+	 */
+	async passiveLogin () {
+		throw new TypeError("Not implemented");
+	}
+
 	async logout () {}
 
 	static phrases = {

--- a/src/oauth-backend.js
+++ b/src/oauth-backend.js
@@ -139,7 +139,7 @@ export default class OAuthBackend extends AuthBackend {
 			return this.getUser();
 		}
 
-		await passiveLogin(rest);
+		await this.passiveLogin(rest);
 
 		if (this.isAuthenticated()) {
 			try {

--- a/src/oauth-backend.js
+++ b/src/oauth-backend.js
@@ -218,30 +218,26 @@ export default class OAuthBackend extends AuthBackend {
 	/**
 	 * oAuth logout helper
 	 */
-	async logout ({force = false} = {}) {
-		let wasAuthenticated = this.isAuthenticated();
+	async logout () {
+		super.logout();
 
-		if (wasAuthenticated || force) {
-			localStorage.removeItem(this.constructor.tokenKey);
-			delete this.accessToken;
-
+		if (!this.isAuthenticated()) {
 			// TODO does this really represent all backends? Should it be a setting?
 			this.updatePermissions({
 				edit: false,
 				add: false,
 				delete: false,
 				save: false,
-				login: true
 			});
-
-			this.user = null;
-
-			if (wasAuthenticated) {
-				// We may force logout to clean up corrupt data
-				// But we don't want to trigger a logout event in that case
-				this.dispatchEvent(new CustomEvent("mv-logout"));
-			}
 		}
+	}
+
+	/**
+	 * Delete any info used to log users in passively
+	 */
+	deleteLocalUserInfo () {
+		localStorage.removeItem(this.constructor.tokenKey);
+		delete this.accessToken;
 	}
 
 	static get tokenKey () {

--- a/src/oauth-backend.js
+++ b/src/oauth-backend.js
@@ -139,9 +139,12 @@ export default class OAuthBackend extends AuthBackend {
 			return this.getUser();
 		}
 
+		// We try passive login first even if this is an active login
+		// Or should we not? Perhaps we should treat an active log in as an implicit log out request?
 		await this.passiveLogin(rest);
 
 		if (this.isAuthenticated()) {
+			// We seem to have credentials already, but are they valid?
 			try {
 				await this.getUser()
 			}


### PR DESCRIPTION
Initial API sketch, still under development


- Backends should not be concerned with throwing events, unless the event is specific to the backend. Otherwise, these should be handled by the Madata base classes

A lot of the code handling OAuth login is actually unrelated to OAuth, and more generally applicable to all auth backends

I moved that code up to `AuthBackend`, then created two new methods for backends to override: `activeLogin()` and `passiveLogin()`. If these are properly implemented, the actual login flow can be handled more generically.

I also added a `force` option to logout, intended for cleanup, without observable side effects. Not sure if this is a good idea.