### PR TITLE
Add footer with links to the terms of service and privacy policy

### DIFF
--- a/_includes/page.njk
+++ b/_includes/page.njk
@@ -39,6 +39,17 @@
 
 {% if page.url and page.url !== "/" %}</main>{% endif %}
 
+<footer>
+	<div class="logo">
+		<img src="{{ page | relative }}/logo.svg" alt="logo" /> madata
+	</div>
+
+	<nav>
+		<a href="/terms-of-service">Terms of Service</a> &bull;
+		<a href="/privacy-policy">Privacy Policy</a>
+	</nav>
+</footer>
+
 <script src="{{ page | relative }}/global.js" type="module"></script>
 
 </body>

--- a/style.postcss
+++ b/style.postcss
@@ -293,9 +293,42 @@ body > * {
 			}
 		}
 	}
+
+	&:is(footer) {
+		margin-top: 2em;
+		padding-block: 2em;
+		font-size: 85%;
+		background: hsl(var(--gray) 95%);
+
+		& > .logo {
+			display: flex;
+			gap: .3em;
+			align-items: center;
+			justify-content:flex-end;
+			font: 900 italic 130%/1 var(--font-heading);
+			color: hsl(var(--color-blue-hs) 30%);
+
+			& img {
+				width: auto;
+				height: 2.8em;
+			}
+		}
+
+		& > nav {
+			margin-top: .2em;
+			text-align: right;
+			font-weight: 500;
+
+			& a {
+				&:where(:not(:hover)) {
+					text-decoration: none;
+				}
+			}
+		}
+	}
 }
 
-nav {
+body > nav {
 	order: 1;
 	display: flex;
 	padding-top: 0;
@@ -321,6 +354,8 @@ nav {
 }
 
 main {
+	flex: 1 0 auto;
+
 	& > h1,
 	& > h2:first-child:only-of-type {
 		font-size: 300%;


### PR DESCRIPTION
We need this to verify the app with Google.

It's a very simple footer inspired by the one on Codepen:

<img width="1108" alt="image" src="https://github.com/madatajs/madata/assets/9166277/f4ebe50b-6f26-4db3-b145-eaf2bbbe6943">

We can improve it later.