### PR TITLE
Do not error if we don't have an access token

### DIFF
--- a/src/oauth-backend.js
+++ b/src/oauth-backend.js
@@ -192,7 +192,7 @@ export default class OAuthBackend extends AuthBackend {
 			this.updatePermissions({login: false, logout: true});
 			return currentUser;
 		}
-		else {
+		else if (this.isAuthenticated()) {
 			throw new Error(this.constructor.phrase("invalid_access_token"));
 		}
 	}


### PR DESCRIPTION
Currently, the `login()` method errors on every passive login. I believe that shouldn't have happened if the author neither provided the access token programmatically nor had them in the local storage. There are cases when the access token isn't needed, e.g., for public Google Sheets, GitHub Gists, public repos, etc. The author might only read the data from such sources. That's why I propose this fix. 😊