### PR TITLE
Import the default formats in the base backend class

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -4,6 +4,7 @@
  * @extends EventTarget
  */
 import Format from "./format.js";
+import "../formats/index.js";
 import hooks from "./hooks.js";
 import { toArray, phrase, type } from "./util.js";
 


### PR DESCRIPTION
So that they are imported, registered, and available in subclasses.

For now, if the developer creates a backend directly from a subclass (e.g., `GithubFile`), not the `Backend` class, the default formats are not registered, i.e., unavailable.

Without the fix, on publishing the app in My Lifesheets, we get an error in the console:

<img width="470" alt="SCR-20231204-ugxi" src="https://github.com/madatajs/madata/assets/9166277/c71a3033-dbcb-4c58-b73f-be6435657e58">

With the fix, the publishing is successful:

<img width="1082" alt="SCR-20231204-uhqf" src="https://github.com/madatajs/madata/assets/9166277/62881c4f-a653-49a7-aabb-fc6dccfae43f">

**UPDATE:**
Without the fix, we can't also load data:

<img width="452" alt="SCR-20231204-upjs" src="https://github.com/madatajs/madata/assets/9166277/3df22faf-5ae6-4246-907c-a49eddf95ee4">
