### PR TITLE
More general URL handling

### DIFF
--- a/backends/basic/local.js
+++ b/backends/basic/local.js
@@ -36,13 +36,10 @@ export default class Local extends Backend {
 	}
 
 	static parseURL (source) {
-		const url = new URL(source);
-		let key = url.pathname;
-		return {key};
+		let ret = super.parseURL(source);
+		ret.key = ret.url.pathname;
+		return ret;
 	}
 
-	static test (source) {
-		let url = new URL(source);
-		return url.protocol == "local:";
-	}
+	static protocol = "local:";
 }

--- a/backends/coda/api/coda-api.js
+++ b/backends/coda/api/coda-api.js
@@ -5,7 +5,5 @@ export default class CodaAPI extends Coda {
 		return this.request(file.url);
 	}
 
-	static test (url) {
-		return url.startsWith(this.apiDomain);
-	}
+	static path = "/apis/v1/";
 }

--- a/backends/coda/coda.js
+++ b/backends/coda/coda.js
@@ -39,6 +39,7 @@ export default class Coda extends OAuthBackend {
 	}
 
 	static apiDomain = "https://coda.io/apis/v1/";
+	static host = "coda.io";
 
 	static phrases = {
 		"login_prompt": "Enter your Coda API token. You can find it in your Coda account settings."

--- a/backends/coda/table/coda-table.js
+++ b/backends/coda/table/coda-table.js
@@ -1,9 +1,4 @@
 import Coda from "../coda.js";
-// https://coda.io/d/State-of-HTML-Planning_dTGBFYq175J/All-considered-features_suY7G#In-Part-1_tuBsZ/r1
-const patterns = {
-	api: /\/apis\/v1\/docs\/(?<docId>[\w-]+)\/tables\/(?<tableId>[\w-]+)\//,
-	browserLink: /\/d\/[a-zA-Z\d-]*?_d(?<docId>[\w-]+)(\/[a-zA-Z\d-]*?(?<tentativePageId>_s[\w-]+))?/
-};
 
 export default class CodaTable extends Coda {
 	async get (file = this.file) {
@@ -95,21 +90,13 @@ export default class CodaTable extends Coda {
 		return items;
 	}
 
-	static parseURL (source) {
-		let url = new URL(source);
+	static path = "/d/";
 
-		if (url.host === "coda.io") {
-			for (let pattern in patterns) {
-				let match = url.pathname.match(patterns[pattern]);
-
-				if (match) {
-					return Object.assign({}, match.groups);
-				}
-			}
-		}
-
-		return {};
-	}
+	// Example URL: https://coda.io/d/State-of-HTML-Planning_dTGBFYq175J/All-considered-features_suY7G#In-Part-1_tuBsZ/r1
+	static patterns = {
+		api: /\/apis\/v1\/docs\/(?<docId>[\w-]+)\/tables\/(?<tableId>[\w-]+)\//,
+		browserLink: /\/d\/[a-zA-Z\d-]*?_d(?<docId>[\w-]+)(\/[a-zA-Z\d-]*?(?<tentativePageId>_s[\w-]+))?/
+	};
 
 	/**
 	 * Convert JSON-LD structured objects to plain strings whenever possible

--- a/backends/dropbox/index.js
+++ b/backends/dropbox/index.js
@@ -83,16 +83,13 @@ export default class Dropbox extends OAuthBackend {
 		return this.user;
 	}
 
-	static test (url) {
-		url = new URL(url, location);
-		return /dropbox.com/.test(url.host);
-	}
+	static host = "*.dropbox.com";
 
 	static parseURL (source) {
-		let { url } = super.parseURL(source);
-		url = Dropbox.#fixShareURL(url);
-
-		return {url};
+		let ret = super.parseURL(source);
+		ret.originalURL = ret.url;
+		ret.url = Dropbox.#fixShareURL(ret.url);
+		return ret;
 	}
 
 	// Transform the dropbox shared URL into something raw and CORS-enabled

--- a/backends/firebase/index.js
+++ b/backends/firebase/index.js
@@ -272,10 +272,10 @@ export default class Firebase extends AuthBackend {
 		path: "madata/data"
 	};
 
-	static test (url) {
-		url = new URL(url);
-		return url.host.endsWith("firebaseio.com");
-	}
+	static urls = [
+		{ host: "*.firebaseio.com" },
+		{ host: "firebasestorage.googleapis.com" },
+	];
 
 	/**
 	 * Parse URL.
@@ -283,9 +283,7 @@ export default class Firebase extends AuthBackend {
 	 * @returns Project ID, auth domain, storage bucket | A flag whether a file is in Firebase Storage, file URL.
 	 */
 	static parseURL (source) {
-		const ret = {
-			url: new URL(source)
-		};
+		const ret = super.parseURL(source);
 
 		if (ret.url.host === "firebasestorage.googleapis.com" || ret.url.protocol === "gs:") {
 			ret.inStorage = true;

--- a/backends/github/api/github-api.js
+++ b/backends/github/api/github-api.js
@@ -72,15 +72,10 @@ export default class GithubAPI extends Github {
 		return json;
 	}
 
-	static test (url) {
-		url = new URL(url);
-		return url.host === "api.github.com";
-	}
+	static host = "api.github.com";
 
 	static parseURL (source) {
-		let ret = {
-			url: new URL(source)
-		};
+		let ret = super.parseURL(source);
 
 		if (ret.url.pathname == "/graphql") {
 			if (ret.url.hash) {

--- a/backends/github/file/github-file.js
+++ b/backends/github/file/github-file.js
@@ -426,28 +426,27 @@ export default class GithubFile extends Github {
 		"no_push_permission": (repo) => `You do not have permission to write to repository ${repo}`,
 	};
 
-	static test (url) {
-		url = new URL(url);
-		return ["github.com", "raw.githubusercontent.com"].includes(url.host);
-	}
+	static urls = [
+		{ host: "github.com" },
+		{ host: "raw.githubusercontent.com" }
+	];
 
 	/**
 	 * Parse Github URLs, return username, repo, branch, path
 	 */
 	static parseURL (source) {
-		const ret = {
+		let ret = Object.assign(super.parseURL(source), {
 			owner: undefined,
 			repo: undefined,
 			branch: undefined,
 			path: undefined,
-		};
+		});
 
 		if (!source) {
 			return ret;
 		}
 
-		const url = new URL(source);
-
+		const url = ret.url;
 		let path = url.pathname.slice(1).split("/");
 
 		ret.owner = path.shift();

--- a/backends/github/gist/github-gist.js
+++ b/backends/github/gist/github-gist.js
@@ -94,22 +94,18 @@ export default class GithubGist extends Github {
 		return this.request(`gists/${file.gistId}/forks`, {}, "POST");
 	}
 
+	static host = "gist.github.com";
+
 	static defaults = {
 		path: "data.json",
-	}
-
-	static test (url) {
-		url = new URL(url);
-		return url.host === "gist.github.com";
 	}
 
 	/**
 	 * Parse Gist URLs, return username, gist id, filename
 	 */
 	static parseURL (source) {
-		let ret = {};
-		let url = new URL(source);
-		let path = url.pathname.slice(1).split("/");
+		let ret = super.parseURL(source);
+		let path = ret.url.pathname.slice(1).split("/");
 
 		ret.owner = path.shift();
 		ret.gistId = path.shift();

--- a/backends/google/calendar/google-calendar.js
+++ b/backends/google/calendar/google-calendar.js
@@ -54,11 +54,7 @@ export default class GoogleCalendar extends Google {
 	static supportedOptions = ["iCalUID", "maxAttendees", "maxResults", "orderBy", "pageToken", "privateExtendedProperty", "q", "sharedExtendedProperty", "showDeleted", "showHiddenInvitations", "singleEvents", "syncToken", "timeMax", "timeMin", "timeZone", "updatedMin"];
 	static apiDomain = "https://www.googleapis.com/calendar/v3/calendars/";
 	static scopes = ["https://www.googleapis.com/auth/calendar.events", "https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"];
-
-	static test (url) {
-		url = new URL(url);
-		return url.host === "calendar.google.com";
-	}
+	static host = "calendar.google.com"
 
 	/**
 	 * Parse Calendars URLs.
@@ -66,9 +62,7 @@ export default class GoogleCalendar extends Google {
 	 * @returns Calendar ID.
 	 */
 	static parseURL (source) {
-		const ret = {
-			url: new URL(source)
-		};
+		const ret = super.parseURL(source);
 		const params = ret.url.searchParams;
 
 		let calendarId;

--- a/backends/google/calendar/google-calendar.js
+++ b/backends/google/calendar/google-calendar.js
@@ -54,7 +54,7 @@ export default class GoogleCalendar extends Google {
 	static supportedOptions = ["iCalUID", "maxAttendees", "maxResults", "orderBy", "pageToken", "privateExtendedProperty", "q", "sharedExtendedProperty", "showDeleted", "showHiddenInvitations", "singleEvents", "syncToken", "timeMax", "timeMin", "timeZone", "updatedMin"];
 	static apiDomain = "https://www.googleapis.com/calendar/v3/calendars/";
 	static scopes = ["https://www.googleapis.com/auth/calendar.events", "https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"];
-	static host = "calendar.google.com"
+	static host = "calendar.google.com";
 
 	/**
 	 * Parse Calendars URLs.

--- a/backends/google/drive/google-drive.js
+++ b/backends/google/drive/google-drive.js
@@ -267,10 +267,7 @@ export default class GoogleDrive extends Google {
 		}
 	}
 
-	static test (url) {
-		url = new URL(url);
-		return url.host === "drive.google.com";
-	}
+	static host = "drive.google.com";
 
 	static defaults = {
 		filename: "data.json",
@@ -288,12 +285,11 @@ export default class GoogleDrive extends Google {
 	 * @returns URL, filename, [folder URL], [folder id], fields.
 	 */
 	static parseURL (source) {
-		const ret = {
-			url: new URL(source),
+		let ret = Object.assign(super.parseURL(source), {
 			filename: undefined,
 			folder: undefined,
 			fields: undefined
-		};
+		});
 
 		const path = ret.url.pathname.slice(1).split("/");
 		const type = path[0];

--- a/backends/google/sheets/google-sheets.js
+++ b/backends/google/sheets/google-sheets.js
@@ -449,9 +449,8 @@ export default class GoogleSheets extends Google {
 	static apiDomain = "https://sheets.googleapis.com/v4/spreadsheets/";
 	static scopes = ["https://www.googleapis.com/auth/spreadsheets", "https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"];
 
-	static test (url) {
-		return url.startsWith("https://docs.google.com/spreadsheets/");
-	}
+	static host = "docs.google.com";
+	static path = "/spreadsheets/";
 
 	/**
 	 * Parse spreadsheets URLs.
@@ -459,12 +458,12 @@ export default class GoogleSheets extends Google {
 	 * @returns Spreadsheet ID, sheet ID, sheet title, range.
 	 */
 	static parseURL (source) {
-		const ret = {
-			url: new URL(source),
+		let ret = Object.assign(super.parseURL(source), {
 			sheetId: undefined,
 			sheet: undefined,
-			range: undefined
-		};
+			range: undefined,
+		});
+
 		const path = ret.url.pathname.slice(1).split("/");
 		const hash = ret.url.hash;
 

--- a/src/util.js
+++ b/src/util.js
@@ -101,7 +101,7 @@ export function testURL (url, criteria) {
 
 	let {protocol, host, path} = criteria;
 
-	if (protocol && url.protocol != protocol) {
+	if (protocol && url.protocol !== protocol) {
 		return false;
 	}
 

--- a/src/util.js
+++ b/src/util.js
@@ -95,7 +95,7 @@ export function testURL (url, criteria) {
 		url = new URL(url);
 	}
 
-	if (Array.isArray(criteria.urls)) {
+	if (Array.isArray(criteria)) {
 		return criteria.urls.some(pattern => testURL(url, pattern));
 	}
 

--- a/src/util.js
+++ b/src/util.js
@@ -96,7 +96,7 @@ export function testURL (url, criteria) {
 	}
 
 	if (Array.isArray(criteria)) {
-		return criteria.urls.some(pattern => testURL(url, pattern));
+		return criteria.some(pattern => testURL(url, pattern));
 	}
 
 	let {protocol, host, path} = criteria;

--- a/src/util.js
+++ b/src/util.js
@@ -114,7 +114,7 @@ export function testURL (url, criteria) {
 				return false;
 			}
 		}
-		else if (url.host != host) {
+		else if (url.host !== host) {
 			return false;
 		}
 	}

--- a/src/util.js
+++ b/src/util.js
@@ -83,3 +83,45 @@ export function phrase (me, id, ...args) {
 	// Fall back to just displaying the id and all the args right after it
 	return id + " " + args.join(" ");
 }
+
+/**
+ * Test whether a URL matches a set of criteria
+ * @param {string | URL} url
+ * @param {{protocol, host, urls} | {protocol, host, urls}[]} criteria
+ * @returns {boolean}
+ */
+export function testURL (url, criteria) {
+	if (typeof url === "string") {
+		url = new URL(url);
+	}
+
+	if (Array.isArray(criteria.urls)) {
+		return criteria.urls.some(pattern => testURL(url, pattern));
+	}
+
+	let {protocol, host, path} = criteria;
+
+	if (protocol && url.protocol != protocol) {
+		return false;
+	}
+
+	if (host) {
+		if (host.startsWith("*.")) {
+			// Wildcard subdomain
+			host = host.replace(/^(\*\.)+/, "");
+
+			if (url.host !== host && !url.host.endsWith("." + host)) {
+				return false;
+			}
+		}
+		else if (url.host != host) {
+			return false;
+		}
+	}
+
+	if (path && !url.pathname.startsWith(path)) {
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
- Backends can define URL criteria in which case they don't need to define a `test()` function, the base one Just Works™
- Backends can define URL regex patterns, which get parsed automatically. We could also use `URLPattern` in the future.
- For backends with a singular `host`, users can now use relative URLs with backends (useful for when they are not using `Backend.from()` but specifying the backend directly. Maybe we should extend this to backends with multiple hosts and just use the first one.