### PR TITLE
Moving from `file` to `ref`

### DIFF
--- a/backends/basic/local.js
+++ b/backends/basic/local.js
@@ -17,8 +17,8 @@ export default class Local extends Backend {
 	}
 
 	async get () {
-		if (this.file.key in localStorage) {
-			return localStorage[this.file.key];
+		if (this.ref.key in localStorage) {
+			return localStorage[this.ref.key];
 		}
 
 		return null;
@@ -26,12 +26,12 @@ export default class Local extends Backend {
 
 	async put (data) {
 		if (!data) {
-			delete localStorage[this.file.key];
+			delete localStorage[this.ref.key];
 			return {type: "delete"};
 		}
 
-		let exists = this.file.key in localStorage;
-		localStorage[this.file.key] = await this.stringify(data);
+		let exists = this.ref.key in localStorage;
+		localStorage[this.ref.key] = await this.stringify(data);
 		return {type: exists ? "update" : "create"};
 	}
 

--- a/backends/coda/api/coda-api.js
+++ b/backends/coda/api/coda-api.js
@@ -1,8 +1,8 @@
 import Coda from "../coda.js";
 
 export default class CodaAPI extends Coda {
-	async get (file = this.file) {
-		return this.request(file.url);
+	async get (ref = this.ref) {
+		return this.request(ref.url);
 	}
 
 	static path = "/apis/v1/";

--- a/backends/github/api/github-api.js
+++ b/backends/github/api/github-api.js
@@ -8,10 +8,10 @@ export default class GithubAPI extends Github {
 		Object.assign(this, GithubAPI.parseURL(this.source));
 	}
 
-	async get (file = this.file) {
-		if (file.query) {
+	async get (ref = this.ref) {
+		if (ref.query) {
 			// GraphQL
-			let response = await this.request(file.url, { query: file.query }, "POST");
+			let response = await this.request(ref.url, { query: ref.query }, "POST");
 			if (response.errors?.length) {
 				throw new Error(response.errors.map(x => x.message).join("\n"));
 			}
@@ -25,7 +25,7 @@ export default class GithubAPI extends Github {
 				"Accept": "application/vnd.github.squirrel-girl-preview"
 			}
 		};
-		let response = await this.request(file.apiCall, {}, "GET", req);
+		let response = await this.request(ref.apiCall, {}, "GET", req);
 
 		if (!response || !response.ok) {
 			return null;
@@ -34,7 +34,7 @@ export default class GithubAPI extends Github {
 		// Raw API call
 		let json = await response.json();
 
-		let params = new URL(file.apiCall, this.constructor.apiDomain).searchParams;
+		let params = new URL(ref.apiCall, this.constructor.apiDomain).searchParams;
 		let maxPages = params.get("max_pages") - 1; /* subtract 1 because we already fetched a page */
 
 		if (maxPages > 0 && params.get("page") === null && Array.isArray(json)) {

--- a/backends/github/file/github-file.js
+++ b/backends/github/file/github-file.js
@@ -14,7 +14,7 @@ export default class GithubFile extends Github {
 	 * @param {Object} file
 	 * @returns {string} File contents as a string, or `null` if not found
 	 */
-	async get (file = this.file) {
+	async get (file = this.ref) {
 		if (this.isAuthenticated()) {
 			let call = `repos/${file.owner}/${file.repo}/contents/${file.path}`;
 
@@ -88,7 +88,7 @@ export default class GithubFile extends Github {
 		return this.#write("put", file, serialized, {isEncoded});
 	}
 
-	async delete (file = this.file) {
+	async delete (file = this.ref) {
 		return this.#write("delete", file);
 	}
 
@@ -172,22 +172,22 @@ export default class GithubFile extends Github {
 		if (user) {
 			this.updatePermissions({edit: true, save: true});
 
-			if (!this.file.owner) {
-				Object.defineProperty(this.file, "owner", {
+			if (!this.ref.owner) {
+				Object.defineProperty(this.ref, "owner", {
 					get: () => this.user.username,
 					set: (value) => {
 						console.log(`setting owner from ${this.user.username} to ${value}`);
-						delete this.file.owner;
-						this.file.owner = value;
+						delete this.ref.owner;
+						this.ref.owner = value;
 					},
 					configurable: true,
 					enumerable: true,
 				});
 			}
 
-			if (this.file.repo) {
+			if (this.ref.repo) {
 				// TODO move to load()?
-				this.file.repoInfo = await this.fetchRepoInfo();
+				this.ref.repoInfo = await this.fetchRepoInfo();
 			}
 		}
 
@@ -207,8 +207,8 @@ export default class GithubFile extends Github {
 		return this.getFileURL(path, {sha: fileInfo.commit.sha});
 	}
 
-	async canPush (ref = this.file) {
-		ref = this._getFile(ref);
+	async canPush (ref = this.ref) {
+		ref = this._getRef(ref);
 
 		await this.fetchRepoInfo(ref);
 
@@ -223,27 +223,27 @@ export default class GithubFile extends Github {
 	}
 
 	async createRepo (ref, options = {}) {
-		ref = this._getFile(ref);
+		ref = this._getRef(ref);
 		let name = ref.repo;
 
 		// FIXME this won't work for orgs
 		ref.repoInfo = await this.request("user/repos", {name, private: this.options.private === true, ...options}, "POST");
 
-		// Update this.file.repoInfo too
-		if (!this.file.repoInfo && this.constructor.sameRepo(ref, this.file)) {
-			this.file.repoInfo = ref.repoInfo;
+		// Update this.ref.repoInfo too
+		if (!this.ref.repoInfo && this.constructor.sameRepo(ref, this.ref)) {
+			this.ref.repoInfo = ref.repoInfo;
 		}
 
 		return ref;
 	}
 
-	async fetchRepoInfo (ref = this.file) {
-		ref = this._getFile(ref);
+	async fetchRepoInfo (ref = this.ref) {
+		ref = this._getRef(ref);
 
 		if (!ref.repoInfo) {
-			if (ref !== this.file && this.file.repoInfo && this.constructor.sameRepo(ref, this.file)) {
+			if (ref !== this.ref && this.ref.repoInfo && this.constructor.sameRepo(ref, this.ref)) {
 				// Same repo as the main repo
-				ref.repoInfo = this.file.repoInfo;
+				ref.repoInfo = this.ref.repoInfo;
 			}
 			else if (ref.owner && ref.repo) {
 				ref.repoInfo = await this.request(`repos/${ref.owner}/${ref.repo}`);
@@ -267,7 +267,7 @@ export default class GithubFile extends Github {
 	 * @param {Object} repoInfo
 	 * @returns {Object} repoInfo object about the fork or null
 	 */
-	async getMyFork (repoInfo = this.file.repoInfo) {
+	async getMyFork (repoInfo = this.ref.repoInfo) {
 		let myRepoCount = this.user.public_repos + this.user.total_private_repos;
 
 		if (myRepoCount < repoInfo.forks) {
@@ -318,7 +318,7 @@ export default class GithubFile extends Github {
 	 * @param [options.force=false] {Boolean} Force a new repo to be created. If false, will try to find an existing fork of the repo.
 	 * @returns
 	 */
-	async fork (file = this.file, {force = false} = {}) {
+	async fork (file = this.ref, {force = false} = {}) {
 		let repoCall = `repos/${file.repoInfo.full_name}`;
 
 		if (!force) {
@@ -347,7 +347,7 @@ export default class GithubFile extends Github {
 		return forkInfo;
 	}
 
-	async publish (file = this.file, {https_enforced = true} = {}) {
+	async publish (file = this.ref, {https_enforced = true} = {}) {
 		let source = {
 			branch: file.branch || "main",
 		};
@@ -369,7 +369,7 @@ export default class GithubFile extends Github {
 		return pagesInfo;
 	}
 
-	async getPagesInfo (ref = this.file) {
+	async getPagesInfo (ref = this.ref) {
 		ref = await this.fetchRepoInfo(ref);
 
 		if (ref.repoInfo) {
@@ -382,7 +382,7 @@ export default class GithubFile extends Github {
 		}
 	}
 
-	async getRepoURL (file = this.file, {
+	async getRepoURL (file = this.ref, {
 		sha = file.branch || "latest",
 	} = {}) {
 		if (this.options.repoURL) {
@@ -404,7 +404,7 @@ export default class GithubFile extends Github {
 	/**
 	 * Get a public URL for a file in a repo
 	 */
-	async getFileURL (path = this.path, {repoInfo = this.file.repoInfo, ...options} = {}) {
+	async getFileURL (path = this.path, {repoInfo = this.ref.repoInfo, ...options} = {}) {
 		let repoURL = this.getRepoURL(repoInfo, options);
 
 		if (!repoURL.endsWith("/")) {

--- a/backends/github/gist/github-gist.js
+++ b/backends/github/gist/github-gist.js
@@ -7,7 +7,7 @@ import Github from "../github.js";
 import hooks from "../../../src/hooks.js";
 
 export default class GithubGist extends Github {
-	async get (file = this.file) {
+	async get (file = this.ref) {
 		if (this.isAuthenticated()) {
 			// Authenticated API call
 			if (file.gistId) {
@@ -48,7 +48,7 @@ export default class GithubGist extends Github {
 		}
 	}
 
-	async put (data, {file = this.file} = {}) {
+	async put (data, {file = this.ref} = {}) {
 		let call = "gists";
 		let gistId = file.gistId;
 
@@ -84,13 +84,13 @@ export default class GithubGist extends Github {
 		return gistInfo;
 	}
 
-	async canPush (file = this.file) {
+	async canPush (file = this.ref) {
 		// Just check if authenticated user is the same as our URL username
 		// A gist can't have multiple collaborators
 		return this.user && this.user.username.toLowerCase() == file.owner.toLowerCase();
 	}
 
-	async fork (file = this.file) {
+	async fork (file = this.ref) {
 		return this.request(`gists/${file.gistId}/forks`, {}, "POST");
 	}
 

--- a/backends/google/calendar/google-calendar.js
+++ b/backends/google/calendar/google-calendar.js
@@ -6,20 +6,20 @@
 import Google from "../google.js";
 
 export default class GoogleCalendar extends Google {
-	async get (file = this.file) {
-		let call = `${file.calendarId}/events?key=${this.apiKey}`;
+	async get (ref = this.ref) {
+		let call = `${ref.calendarId}/events?key=${this.apiKey}`;
 
 		if (this.options) {
-			file.params = Object.assign({}, this.options);
+			ref.params = Object.assign({}, this.options);
 			for (const o of Object.keys(this.options)) {
 				// Do not include in the request options not supported by the Google Calendar API
 				// to avoid getting the “Bad Request” error if possible.
 				if (!GoogleCalendar.supportedOptions.includes(o)) {
-					delete file.params[o];
+					delete ref.params[o];
 				}
 			}
 
-			const params = new URLSearchParams(file.params);
+			const params = new URLSearchParams(ref.params);
 			call = call + "&" + params.toString();
 		}
 
@@ -34,7 +34,7 @@ export default class GoogleCalendar extends Google {
 			}
 
 			if (e.status === 400) {
-				throw new Error(this.constructor.phrase("bad_options", file.params));
+				throw new Error(this.constructor.phrase("bad_options", ref.params));
 			}
 
 			let error;

--- a/backends/google/drive/google-drive.js
+++ b/backends/google/drive/google-drive.js
@@ -16,11 +16,11 @@ export default class GoogleDrive extends Google {
 			const folderId = GoogleDrive.#getFolderId(o.folder);
 
 			if (!folderId) {
-				delete this.file.folder;
+				delete this.ref.folder;
 				return;
 			}
 
-			this.file.folderId = folderId;
+			this.ref.folderId = folderId;
 		}
 
 		if (o.fields) {
@@ -29,11 +29,11 @@ export default class GoogleDrive extends Google {
 			const customFields = o.fields.split(/,\s*/);
 			const fields = [...defaultFields, ...customFields];
 
-			this.file.fields = [...new Set(fields)].join(","); // Drop duplicates.
+			this.ref.fields = [...new Set(fields)].join(","); // Drop duplicates.
 		}
 	}
 
-	async get (file = this.file) {
+	async get (file = this.ref) {
 		if (!file.id) {
 			// There is no file to work with.
 			// We might have a URL of a folder (instead of a file) in which the file will be stored.
@@ -63,7 +63,7 @@ export default class GoogleDrive extends Google {
 		}
 	}
 
-	async put (data, {file} = {}) {
+	async put (data, {file = this.ref} = {}) {
 		const serialized = await this.stringify(data, {file});
 		let fileInfo;
 

--- a/src/backend.js
+++ b/src/backend.js
@@ -138,7 +138,7 @@ export default class Backend extends EventTarget {
 	/**
 	 * Low-level method to fetch data from the backend. Subclasses should override this method.
 	 * Clients should not call this method directly, but use `load()` instead.
-	 * @param {object} ref - reference to the object to fetch, if different from that provided in the constructor
+	 * @param {object} ref - reference to data to fetch, if different from that provided in the constructor
 	 * @returns {string} - Data from the backend as a string, `null` if not found
 	 */
 	async get (ref = this.ref) {

--- a/src/backend.js
+++ b/src/backend.js
@@ -42,17 +42,17 @@ export default class Backend extends EventTarget {
 			this.source = source;
 		}
 
-		if (source || !this.file) {
-			this.file = this._getFile(source);
+		if (source || !this.ref) {
+			this.ref = this._getRef(source);
 		}
 
 		if (o) {
 			this.options = Object.assign(this.options ?? {}, o);
 
 			// Options object has higher priority than url
-			for (let prop in this.file) {
+			for (let prop in this.ref) {
 				if (prop in o) {
-					this.file[prop] = o[prop];
+					this.ref[prop] = o[prop];
 				}
 			}
 		}
@@ -138,11 +138,11 @@ export default class Backend extends EventTarget {
 	/**
 	 * Low-level method to fetch data from the backend. Subclasses should override this method.
 	 * Clients should not call this method directly, but use `load()` instead.
-	 * @param {Object} file - file to fetch, if different from that provided in the constructor
+	 * @param {object} ref - reference to the object to fetch, if different from that provided in the constructor
 	 * @returns {string} - Data from the backend as a string, `null` if not found
 	 */
-	async get (file = this.file) {
-		let url = new URL(file.url);
+	async get (ref = this.ref) {
+		let url = new URL(ref.url);
 		if (url.protocol != "data:" && this.constructor.useCache !== false) {
 			url.searchParams.set("timestamp", Date.now()); // ensure fresh copy
 		}
@@ -159,7 +159,7 @@ export default class Backend extends EventTarget {
 		return null;
 	}
 
-	_getFile (ref) {
+	_getRef (ref) {
 		if (typeof ref === "string") {
 			// ref is a URL
 			if (/^\w+:/.test(ref)) {
@@ -168,11 +168,11 @@ export default class Backend extends EventTarget {
 			}
 
 			// Relative path
-			return Object.assign({}, this.file, {path: ref});
+			return Object.assign({}, this.ref, {path: ref});
 		}
 
-		// Either (default) file object, or empty value
-		return ref ?? this.file ?? this.constructor.parseURL();
+		// Either (default) ref object, or empty value
+		return ref ?? this.ref ?? this.constructor.parseURL();
 	}
 
 	/**
@@ -185,9 +185,9 @@ export default class Backend extends EventTarget {
 	async load (url, ...args) {
 		await this.ready;
 
-		let file = this._getFile(url);
+		let ref = this._getRef(url);
 
-		let response = await this.get(file, ...args);
+		let response = await this.get(ref, ...args);
 
 		if (typeof response !== "string") {
 			// Backend did the parsing, we're done here
@@ -198,12 +198,12 @@ export default class Backend extends EventTarget {
 			response = response.replace(/^\ufeff/, ""); // Remove Unicode BOM
 
 			this.rawData = response;
-			this.data = await this.parse(response, { file });
+			this.data = await this.parse(response, { ref });
 		}
 
 		this.dispatchEvent(new CustomEvent("mv-load", {
 			detail: {
-				url, file, response,
+				url, ref, response,
 				data: this.data,
 				rawData: this.rawData,
 				backend: this
@@ -218,7 +218,7 @@ export default class Backend extends EventTarget {
 	 * Subclasses should usually NOT override this method.
 	 * @param {object} data - Data to write to the backend
 	 * @param {object} [o] - Options object
-	 * @returns {object} - If successful, info about the file
+	 * @returns {object} - If successful, info about the stored data
 	 */
 	async store (data, o = {}) {
 		await this.ready;
@@ -227,23 +227,23 @@ export default class Backend extends EventTarget {
 			o = {url: o};
 		}
 
-		let {file, url, ...options} = o;
+		let {ref, url, ...options} = o;
 
-		file = this._getFile(file ?? url);
+		ref = this._getRef(ref ?? url);
 
-		return this.put(data, {file, ...options});
+		return this.put(data, {ref, ...options});
 	}
 
-	async remove (file = this.file) {
+	async remove (ref = this.ref) {
 		await this.ready;
 
 		if (!this.delete) {
 			throw new Error("This backend does not support deleting files");
 		}
 
-		file = this._getFile(file);
+		ref = this._getRef(ref);
 
-		return this.delete(file);
+		return this.delete(ref);
 	}
 
 	toString () {


### PR DESCRIPTION
Closes #62.

### Summary

-  `this.file` → `this.ref` all over the code base
- `Backend._getFile()` → `Backend._getRef()`
- `CodaTable.resolveFile()` → `CodaTable.resolveRef()`
- For file-based backends (and for the `GithubGist` backend (?)), the method param named `file` is preserved (where possible), e.g., `get (file = this.ref)`

It looks like the docs are up-to-date.

Do we need to change or fix anything else?