### PR TITLE
[docs] Remove redundant comments, duplicating info inferred from the definitions

### DIFF
--- a/backends/basic/element.js
+++ b/backends/basic/element.js
@@ -3,8 +3,6 @@ import {$} from "../../src/util.js";
 
 /**
  * Read and write data into an HTML element.
- * @class Element
- * @extends Backend
  * @category Basic
  */
 export default class Element extends Backend {

--- a/backends/basic/local.js
+++ b/backends/basic/local.js
@@ -3,8 +3,6 @@ import { localStorage } from "../../src/node-shims.js";
 
 /**
  * Store data in the browser's localStorage.
- * @class Local
- * @extends Backend
  * @category Basic
  */
 export default class Local extends Backend {

--- a/backends/basic/remote.js
+++ b/backends/basic/remote.js
@@ -2,8 +2,6 @@ import Backend from "../../src/backend.js";
 
 /**
  * Load the URL as a remote resource. No save.
- * @class Remote
- * @extends Backend
  * @category Basic
  */
 export default class Remote extends Backend {

--- a/backends/coda/api/coda-api.js
+++ b/backends/coda/api/coda-api.js
@@ -1,8 +1,6 @@
 import Coda from "../coda.js";
 
 /**
- * @class CodaAPI
- * @extends Coda
  * @category Coda
  */
 export default class CodaAPI extends Coda {

--- a/backends/coda/coda.js
+++ b/backends/coda/coda.js
@@ -1,8 +1,6 @@
 import OAuthBackend from "../../src/oauth-backend.js";
 
 /**
- * @class Coda
- * @extends OAuthBackend
  * @category Coda
  */
 export default class Coda extends OAuthBackend {

--- a/backends/coda/table/coda-table.js
+++ b/backends/coda/table/coda-table.js
@@ -1,8 +1,6 @@
 import Coda from "../coda.js";
 
 /**
- * @class CodaTable
- * @extends Coda
  * @category Coda
  */
 export default class CodaTable extends Coda {

--- a/backends/dropbox/index.js
+++ b/backends/dropbox/index.js
@@ -2,8 +2,6 @@ import OAuthBackend from "../../src/oauth-backend.js";
 
 /**
  * Dropbox backend.
- * @class Dropbox
- * @extends OAuthBackend
  */
 export default class Dropbox extends OAuthBackend {
 	static apiDomain = "https://api.dropboxapi.com/2/";

--- a/backends/firebase/index.js
+++ b/backends/firebase/index.js
@@ -8,8 +8,6 @@ import { getStorage, ref, uploadString, getDownloadURL, deleteObject } from "htt
 
 /**
  * Firebase backend.
- * @class Firebase
- * @extends OAuthBackend
  */
 export default class Firebase extends AuthBackend {
 	constructor (url, o) {

--- a/backends/github/api/github-api.js
+++ b/backends/github/api/github-api.js
@@ -3,8 +3,6 @@ import Github from "../github.js";
 
 /**
  * Backend for performing raw API calls with the REST or GraphQL API to GitHub repositories.
- * @class GithubAPI
- * @extends Github
  * @category GitHub
  */
 export default class GithubAPI extends Github {

--- a/backends/github/file/github-file.js
+++ b/backends/github/file/github-file.js
@@ -4,8 +4,6 @@ import {readFile, delay} from "../../../src/util.js";
 
 /**
  * Backend for reading and writing data and uploading files in GitHub repositories.
- * @class GithubFile
- * @extends Github
  * @category GitHub
  */
 export default class GithubFile extends Github {

--- a/backends/github/gist/github-gist.js
+++ b/backends/github/gist/github-gist.js
@@ -3,8 +3,6 @@ import hooks from "../../../src/hooks.js";
 
 /**
  * Github Gist backend.
- * @class GithubGist
- * @extends Github
  * @category GitHub
  */
 export default class GithubGist extends Github {

--- a/backends/github/github.js
+++ b/backends/github/github.js
@@ -2,8 +2,6 @@ import OAuthBackend from "../../src/oauth-backend.js";
 
 /**
  * Base class for all Github backends, containing auth methods.
- * @class Github
- * @extends OAuthBackend
  * @category GitHub
  */
 export default class Github extends OAuthBackend {

--- a/backends/google/calendar/google-calendar.js
+++ b/backends/google/calendar/google-calendar.js
@@ -2,8 +2,6 @@ import Google from "../google.js";
 
 /**
  * Google Calendar backend. Read-only for now.
- * @class GoogleCalendar
- * @extends Google
  * @category Google
  */
 export default class GoogleCalendar extends Google {

--- a/backends/google/drive/google-drive.js
+++ b/backends/google/drive/google-drive.js
@@ -2,8 +2,6 @@ import Google from "../google.js";
 
 /**
  * Google Drive backend.
- * @class GoogleDrive
- * @extends Google
  * @category Google
  */
 export default class GoogleDrive extends Google {

--- a/backends/google/google.js
+++ b/backends/google/google.js
@@ -2,8 +2,6 @@ import OAuthBackend from "../../src/oauth-backend.js";
 
 /**
  * Base class for all Google backends, containing auth methods.
- * @class Google
- * @extends OAuthBackend
  * @category Google
  */
 export default class Google extends OAuthBackend {

--- a/backends/google/sheets/google-sheets.js
+++ b/backends/google/sheets/google-sheets.js
@@ -2,8 +2,6 @@ import Google from "../google.js";
 
 /**
  * Google Sheets backend.
- * @class GoogleSheets
- * @extends Google
  * @category Google
  */
 export default class GoogleSheets extends Google {

--- a/formats/csv/index.js
+++ b/formats/csv/index.js
@@ -1,10 +1,6 @@
 import Format from "../../src/format.js";
 import { parse, stringify } from "../../lib/csv/dist/esm/sync.js";
 
-/**
- * @class CSV
- * @extends Format
- */
 export default class CSV extends Format {
 	static defaultOptions = {
 		parse: {

--- a/formats/json/index.js
+++ b/formats/json/index.js
@@ -1,9 +1,5 @@
 import Format from "../../src/format.js";
 
-/**
- * @class JSON
- * @extends Format
- */
 export default class JSON extends Format {
 	static defaultOptions = {
 		stringify: {

--- a/formats/text/index.js
+++ b/formats/text/index.js
@@ -1,9 +1,5 @@
 import Format from "../../src/format.js";
 
-/**
- * @class Text
- * @extends Format
- */
 export default class Text extends Format {
 	static extensions = ["txt", "md"];
 	static mimeTypes = ["text/plain"];

--- a/formats/yaml/index.js
+++ b/formats/yaml/index.js
@@ -1,10 +1,6 @@
 import Format from "../../src/format.js";
 import { parse, stringify } from "../../lib/yaml/browser/index.js";
 
-/**
- * @class YAML
- * @extends Format
- */
 export default class YAML extends Format {
 	static extensions = ["yaml", "yml"];
 	static mimeTypes = ["application/yaml", "application/x-yaml", "text/yaml"];

--- a/src/auth-backend.js
+++ b/src/auth-backend.js
@@ -5,8 +5,6 @@ import { toArray } from "./util.js";
 
 /**
  * Backend that supports authentication.
- * @class AuthBackend
- * @extends Backend
  * @abstract
  */
 export default class AuthBackend extends Backend {

--- a/src/backend.js
+++ b/src/backend.js
@@ -11,8 +11,6 @@ Format.register(JSON);
 
 /**
  * Base class for all backends.
- * @class Backend
- * @extends EventTarget
  */
 export default class Backend extends EventTarget {
 	/**

--- a/src/format.js
+++ b/src/format.js
@@ -1,8 +1,5 @@
 /** @module Base */
 
-/**
- * @class Format
- */
 export default class Format {
 	static defaultOptions = {};
 	static extensions = [];

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,7 +1,6 @@
 /** @module Hooks */
 /**
  * A class for adding deep extensibility to any piece of JS code.
- * @class Hooks
  */
 export class Hooks {
 	add (name, callback, first) {

--- a/src/oauth-backend.js
+++ b/src/oauth-backend.js
@@ -7,8 +7,6 @@ import { localStorage } from "./node-shims.js";
 
 /**
  * OAuth 2.0 backends.
- * @class OAuthBackend
- * @extends AuthBackend
  */
 export default class OAuthBackend extends AuthBackend {
 	/**


### PR DESCRIPTION
Every class in our API docs has the class name in the class description section, which TypeDoc takes from the `@class` tag in the corresponding comment.

Here is a couple of examples.

<img width="306" alt="SCR-20240210-tvmv" src="https://github.com/madatajs/madata/assets/9166277/2dda84bf-3363-4e93-8966-d07b2ba6ccca">

<img width="393" alt="SCR-20240210-tvjl" src="https://github.com/madatajs/madata/assets/9166277/50b0276a-c185-4634-a9cd-8c7b865febd4">

<img width="550" alt="SCR-20240210-tvgl" src="https://github.com/madatajs/madata/assets/9166277/577d3d9d-5e51-492b-b03b-c5c889554a44">

As we can see from the screenshots, TypeDoc infers all the needed info about the class (including its base class) from the class definition. So, the information we provide with the `@class` and `@extends` tags becomes redundant. I suggest removing it.

This PR addresses it.

With this PR merged, the redundant info is gone.

<img width="306" alt="SCR-20240210-tytr" src="https://github.com/madatajs/madata/assets/9166277/37463542-a56b-4df4-8ed0-3a82ad115aef">

<img width="430" alt="SCR-20240210-tzuz" src="https://github.com/madatajs/madata/assets/9166277/70f8008f-efba-49be-8080-c7c19f9d3300">

<img width="521" alt="SCR-20240210-tzhv" src="https://github.com/madatajs/madata/assets/9166277/6c9062a9-775b-402e-85a2-5e4926ba7ae6">

What do you think, @LeaVerou?