### PR TITLE
Use URL.pathname to get the file extension

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -89,7 +89,7 @@ export default class Backend extends EventTarget {
 
 		if (!format && this.constructor.fileBased && ref) {
 			// If file-based, try to match the filename first
-			let extension = (ref.filename ?? ref.path ?? ref.url).match(/\.(\w+)$/)?.[1];
+			let extension = (ref.filename ?? ref.path ?? ref.url.pathname).match(/\.(\w+)$/)?.[1];
 			if (extension) {
 				format = Format.find({extension});
 			}


### PR DESCRIPTION
`ref.url` is an instance of `URL` and doesn't have the `match()` method. To get a file extension from the URL, we should obtain it from the `pathname` property. The PR fixes the bug we have for now.