### PR TITLE
Sort backends

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -374,7 +374,21 @@ export default class Backend extends EventTarget {
 
 	static register (Class) {
 		Backend[Class.name] = Class;
-		Backend._all.push(Class);
+
+		// We should find the right place for a backend to be registered among the registered backends:
+		// it should be placed before its parent, if any.
+		let index = Backend._all.length; // place the backend at the end by default
+		for (let i = 0; i < Backend._all.length; i++) {
+			let backend = Backend._all[i];
+			if (Class.prototype instanceof backend) {
+				// Found a parent class, place before it
+				index = i;
+				break;
+			}
+		}
+
+		Backend._all.splice(index, 0, Class);
+
 		return Class;
 	}
 


### PR DESCRIPTION
Subclasses should be registered before their parents.

With this PR, we get the following order:

<img width="428" alt="SCR-20240523-mnnf" src="https://github.com/madatajs/madata/assets/9166277/404d7232-10e9-475c-87ff-90086f511090">

This means that even though `GithubAPI` can handle all URLs supported by `GithubLabels`, if we work with labels, the latter backend has priority (the expected behavior).