### PR TITLE
First stab at adding support for the BibTeX format

### DIFF
--- a/formats/bibtex/README.md
+++ b/formats/bibtex/README.md
@@ -1,0 +1,8 @@
+# BibTeX Format
+
+Uses the [`biblatex-csl-converter`](https://www.npmjs.com/package/biblatex-csl-converter) npm package.
+
+See the [supported options](https://github.com/fiduswriter/biblatex-csl-converter/blob/1a9c5903e7bdf517bcc61e0d61b8befbea91f21e/src/import/biblatex.ts#L33-L110) for low-level usage.
+
+Known issues:
+- doesn't preserve the formatting in the source `.bib` file on saving (see https://github.com/fiduswriter/biblatex-csl-converter/issues/132)

--- a/formats/bibtex/index.js
+++ b/formats/bibtex/index.js
@@ -1,0 +1,22 @@
+import Format from "../../src/format.js";
+import { BibLatexParser, BibLatexExporter } from "https://esm.sh/biblatex-csl-converter/lib/index.js";
+
+export default class BibTeX extends Format {
+	static defaultOptions = {
+		processUnexpected: true,
+		processUnknown: true,
+	};
+
+	static extensions = ["bib"];
+	static mimeTypes = ["text/plain"];
+
+	static parse (str, options) {
+		options = this.resolveOptions(options, "parse");
+		return new BibLatexParser(str, options).parse();
+	}
+
+	static stringify (obj, options) {
+		options = this.resolveOptions(options, "stringify");
+		return new BibLatexExporter(obj.entries, false, options).parse();
+	}
+}

--- a/formats/index-fn.js
+++ b/formats/index-fn.js
@@ -8,3 +8,5 @@ export {default as Text} from "./text/index.js";
 export {default as CSV} from "./csv/index.js";
 export {default as Yaml} from "./yaml/index.js";
 export {default as Toml} from "./toml/index.js";
+export {default as BibTeX} from "./bibtex/index.js";
+export {default as bibtex} from "./bibtex/index.js";


### PR DESCRIPTION
Unfortunately, I couldn't make it work by importing `BibLatexParser` and `BibLatexExporter` from `node_modules` as we do with the TOML format, so I ended up using `https://esm.sh/`.