### PR TITLE
First stab at adding support for GitLab

### DIFF
--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -39,7 +39,7 @@ export default class Gitlab extends OAuthBackend {
 		let { apiCall, path, branch } = ref;
 		let body = {
 			branch,
-			content: await this.stringify(data),
+			content: await this.stringify(data, {ref}),
 			commit_message: `Update file ${ path }`,
 		};
 		return this.request(apiCall, body, "PUT");

--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -30,7 +30,8 @@ export default class Gitlab extends OAuthBackend {
 
 	static parseURL (source) {
 		let ret = super.parseURL(source);
-		ret.fileCall = `projects/${ encodeURIComponent(ret.id) }/repository/files/${ ret.path }`;
+		ret.id = encodeURIComponent(ret.id);
+		ret.fileCall = `projects/${ ret.id }/repository/files/${ ret.path }`;
 		return ret;
 	}
 

--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -1,0 +1,37 @@
+import OAuthBackend from "../../src/oauth-backend.js";
+
+/**
+ * @category GitLab
+ */
+export default class Gitlab extends OAuthBackend {
+	static capabilities = { auth: true, put: false, upload: false };
+	static defaultPermissions = { read: true };
+
+	static fileBased = true;
+
+	static urls = [
+		"http{s}?://gitlab.com/:id(.+)/-/blob/:branch/:path(.+)",
+	];
+
+	static userCall = "user";
+	static userSchema = {
+		username: "username",
+		name: ["name", "username"],
+		avatar: "avatar_url",
+		url: "web_url",
+	};
+
+	static apiDomain = "https://gitlab.com/api/v4/";
+	static oAuth = "https://gitlab.com/oauth/authorize";
+
+	static parseURL (source) {
+		let ret = super.parseURL(source);
+		ret.id = encodeURIComponent(ret.id);
+		return ret;
+	}
+
+	get (ref = this.ref) {
+		let { id, branch, path } = ref;
+		return this.request(`projects/${ id }/repository/files/${ path }/raw?ref=${ branch }`);
+	}
+}

--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -4,7 +4,7 @@ import OAuthBackend from "../../src/oauth-backend.js";
  * @category GitLab
  */
 export default class Gitlab extends OAuthBackend {
-	static capabilities = { auth: true, put: false, upload: false };
+	static capabilities = { auth: true, put: true, upload: false };
 	static defaultPermissions = { read: true };
 
 	static fileBased = true;
@@ -26,12 +26,22 @@ export default class Gitlab extends OAuthBackend {
 
 	static parseURL (source) {
 		let ret = super.parseURL(source);
-		ret.id = encodeURIComponent(ret.id);
+		ret.apiCall = `projects/${ encodeURIComponent(ret.id) }/repository/files/${ ret.path }`;
 		return ret;
 	}
 
 	get (ref = this.ref) {
-		let { id, branch, path } = ref;
-		return this.request(`projects/${ id }/repository/files/${ path }/raw?ref=${ branch }`);
+		let { apiCall, branch } = ref;
+		return this.request(`${ apiCall }/raw?ref=${ branch }`);
+	}
+
+	async put (data, {ref = this.ref} = {}) {
+		let { apiCall, path, branch } = ref;
+		let body = {
+			branch,
+			content: await this.stringify(data),
+			commit_message: `Update file ${ path }`,
+		};
+		return this.request(apiCall, body, "PUT");
 	}
 }

--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -30,6 +30,10 @@ export default class Gitlab extends OAuthBackend {
 		return ret;
 	}
 
+	static phrases = {
+		"updated_file": (name = "file") => "Updated " + name,
+	};
+
 	get (ref = this.ref) {
 		let { apiCall, branch } = ref;
 		return this.request(`${ apiCall }/raw?ref=${ branch }`);
@@ -40,7 +44,7 @@ export default class Gitlab extends OAuthBackend {
 		let body = {
 			branch,
 			content: await this.stringify(data, {ref}),
-			commit_message: `Update file ${ path }`,
+			commit_message: this.constructor.phrase("updated_file", path),
 		};
 		return this.request(apiCall, body, "PUT");
 	}

--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -26,7 +26,7 @@ export default class Gitlab extends OAuthBackend {
 
 	static parseURL (source) {
 		let ret = super.parseURL(source);
-		ret.apiCall = `projects/${ encodeURIComponent(ret.id) }/repository/files/${ ret.path }`;
+		ret.fileCall = `projects/${ encodeURIComponent(ret.id) }/repository/files/${ ret.path }`;
 		return ret;
 	}
 
@@ -35,17 +35,17 @@ export default class Gitlab extends OAuthBackend {
 	};
 
 	get (ref = this.ref) {
-		let { apiCall, branch } = ref;
-		return this.request(`${ apiCall }/raw?ref=${ branch }`);
+		let { fileCall, branch } = ref;
+		return this.request(`${ fileCall }/raw?ref=${ branch }`);
 	}
 
 	async put (data, {ref = this.ref} = {}) {
-		let { apiCall, path, branch } = ref;
+		let { fileCall, path, branch } = ref;
 		let body = {
 			branch,
 			content: await this.stringify(data, {ref}),
 			commit_message: this.constructor.phrase("updated_file", path),
 		};
-		return this.request(apiCall, body, "PUT");
+		return this.request(fileCall, body, "PUT");
 	}
 }

--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -1,10 +1,11 @@
 import OAuthBackend from "../../src/oauth-backend.js";
+import { readFile } from "../../src/util.js";
 
 /**
  * @category GitLab
  */
 export default class Gitlab extends OAuthBackend {
-	static capabilities = { auth: true, put: true, upload: false };
+	static capabilities = { auth: true, put: true, upload: true };
 	static defaultPermissions = { read: true };
 
 	static fileBased = true;
@@ -26,6 +27,7 @@ export default class Gitlab extends OAuthBackend {
 
 	static phrases = {
 		"updated_file": (name = "file") => "Updated " + name,
+		"uploaded_file": (name = "file") => "Uploaded " + name,
 	};
 
 	static parseURL (source) {
@@ -48,5 +50,31 @@ export default class Gitlab extends OAuthBackend {
 			commit_message: this.constructor.phrase("updated_file", path),
 		};
 		return this.request(fileCall, body, "PUT");
+	}
+
+	async upload (file, path = file.name) {
+		let { id, branch } = this.ref;
+		let fileCall = `projects/${ id }/repository/files/${ encodeURIComponent(path) }`;
+
+		let type = file.type;
+		let isText = type.startsWith("text/") || type.startsWith("application/") && !type.endsWith("pdf");
+		let content;
+		if (isText) {
+			content = await readFile(file, "Text");
+		}
+		else {
+			content = await readFile(file);
+			content = content.slice(5); // remove “data:”
+			type = type.replace("+", "\\+"); // escape “+” in, e.g., “image/svg+xml”
+			content = content.replace(RegExp(`^${type}(;base64)?,`), "");
+		}
+
+		let body = {
+			branch,
+			content,
+			commit_message: this.constructor.phrase("uploaded_file", path),
+			encoding: isText ? "text" : "base64",
+		};
+		return this.request(fileCall, body, "POST");
 	}
 }

--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -32,7 +32,7 @@ export default class Gitlab extends OAuthBackend {
 
 	static parseURL (source) {
 		let ret = super.parseURL(source);
-		ret.id = encodeURIComponent(ret.id);
+		["id", "path"].forEach(key => ret[key] = encodeURIComponent(ret[key]));
 		ret.fileCall = `projects/${ ret.id }/repository/files/${ ret.path }`;
 		return ret;
 	}

--- a/backends/gitlab/index.js
+++ b/backends/gitlab/index.js
@@ -24,15 +24,15 @@ export default class Gitlab extends OAuthBackend {
 	static apiDomain = "https://gitlab.com/api/v4/";
 	static oAuth = "https://gitlab.com/oauth/authorize";
 
+	static phrases = {
+		"updated_file": (name = "file") => "Updated " + name,
+	};
+
 	static parseURL (source) {
 		let ret = super.parseURL(source);
 		ret.fileCall = `projects/${ encodeURIComponent(ret.id) }/repository/files/${ ret.path }`;
 		return ret;
 	}
-
-	static phrases = {
-		"updated_file": (name = "file") => "Updated " + name,
-	};
 
 	get (ref = this.ref) {
 		let { fileCall, branch } = ref;

--- a/backends/index-fn.js
+++ b/backends/index-fn.js
@@ -9,3 +9,4 @@ export {default as Dropbox} from "./dropbox/index.js";
 export * from "./google/index.js";
 export * from "./coda/index.js";
 export {default as Firebase} from "./firebase/index.js";
+export {default as Gitlab} from "./gitlab/index.js";


### PR DESCRIPTION
It's the bare minimum (for illustration purposes only):

- Supports `gitlab.com` only (the most helpful thing for GitLab users, from my perspective, is to support hosts like `gitlab.foo.com` or similar)
- ~~Read-only~~ Read/write
- **UPDATE:** Support uploads (has boilerplate, see #99)

It might become a very powerful backend in the future, though.

Also, I'm still researching how to upload files (in a couple of lines). I just need to fix the current state.

P.S. [This PR](https://github.com/madatajs/auth.madata.dev/pull/1) should be merged first for this backend to work.